### PR TITLE
fix: add initialization guard to prevent double plugin init

### DIFF
--- a/addons/godot-iap/godot_iap.gd
+++ b/addons/godot-iap/godot_iap.gd
@@ -27,11 +27,15 @@ signal developer_provided_billing_android(details: Dictionary)
 # Native plugin reference
 var _native_plugin: Object = null
 var _is_connected: bool = false
+var _is_initialized: bool = false
 
 # Platform detection
 var _platform: String = ""
 
 func _ready() -> void:
+	if _is_initialized:
+		return
+	_is_initialized = true
 	_platform = OS.get_name()
 	_init_native_plugin()
 
@@ -177,6 +181,9 @@ func _on_android_developer_provided_billing(details_json: String) -> void:
 ## Returns true if connection was successful
 func init_connection() -> bool:
 	print("[GodotIap] init_connection called")
+	if _is_connected:
+		print("[GodotIap] Already connected, skipping init_connection")
+		return true
 	if _native_plugin:
 		if _platform == "Android":
 			print("[GodotIap] Calling Android initConnection...")


### PR DESCRIPTION
When the plugin is both enabled in ProjectSettings > Plugins AND the godot_iap.gd script is attached as an AutoLoad node, _ready() runs twice causing duplicate initialization, listeners, and state conflicts.

This adds:
- _is_initialized guard in _ready() to prevent double native plugin init
- _is_connected guard in init_connection() to make it idempotent

Closes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced plugin initialization to prevent redundant operations. The plugin now intelligently tracks its internal state and automatically skips unnecessary re-initialization and connection attempts when methods are invoked multiple times, improving overall stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->